### PR TITLE
fix: add zod dependency required by AI SDK

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "remark-gfm": "^4.0.1",
     "stripe": "^22.0.1",
     "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
   "devDependencies": {


### PR DESCRIPTION
The AI SDK packages (`ai`, `@ai-sdk/*`) require `zod` as a peer dependency (`^3.25.76 || ^4.1.8`).

Without `zod` explicitly in `dependencies`, clean installs (like Vercel deployments) fail with:
```
Module not found: Can't resolve 'zod'
```

This PR:
- Adds `zod@^4.3.6` to dependencies
- Adds `.npmrc` with `legacy-peer-deps=true` for peer dep compatibility